### PR TITLE
Implemented getall command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,27 +17,29 @@ Project provides a UI shell command prompt that allows you to manipulate dataset
     ps <arg>                 - where arg is a task/job name   
     pwd                      - show current working dataset
     rm <arg>                 - where arg is "*", member, dataset, or dataset with member value
-    tail <arg1> <arg2>       - where arg1 is job name, arg2 is optional and is line limit - tail job log
+    tail <arg1> <arg2>       - where arg1 is job name, arg2 is optional and is line limit  
+                             - and only job's JESMSGLG spool output is returned
     touch <arg>              - create member arg if it does not already exist
     uname                    - show current connected host name
     whoami                   - show current connected user name
   
 Along with following custom commands:  
 
-    get <arg>                - where arg is a job name - output job log
-    count members           - return member count in dataset
-    count datasets          - return dataset count in dataset
-    cp | copy <arg> arg>    - where arg can be ".", member, dataset or dataset(member)  
-    cancel <arg>            - where arg is a task/job name  
-    connections             - a list of connection(s)   
-    change <arg>            - where arg is a number representing a connection
-    files                   - list all files under local c:\ZosShell  
-    download <arg>          - download arg to local c:\ZosShell where arg is member/seq dataset     
-    end                     - end session closes shell UI window
-    save <arg>              - save arg where arg is a file name from files command to the current pwd
-    search <arg>            - search for arg within a job log from the last get command performed  
-    submit <arg>            - where arg is a member name  
-    v | visited             - a list of visited datasets  
+    get <arg>                - where arg is a job name - returns jobs's JESMSGLG spool output only
+    getall <arg>             - where arg is a job name - returns all the job's combined spool files output 
+    count members            - return member count in dataset
+    count datasets           - return dataset count in dataset
+    cp | copy <arg> arg>     - where arg can be ".", member, dataset or dataset(member)  
+    cancel <arg>             - where arg is a task/job name  
+    connections              - a list of connection(s)   
+    change <arg>             - where arg is a number representing a connection
+    files                    - list all files under local c:\ZosShell  
+    download <arg>           - download arg to local c:\ZosShell where arg is member/seq dataset     
+    end                      - end session closes shell UI window
+    save <arg>               - save arg where arg is a file name from files command to the current pwd
+    search <arg>             - search for arg within a job log from the last get command performed  
+    submit <arg>             - where arg is a member name  
+    v | visited              - a list of visited datasets  
   
 The following key combinations provide the following functionality within the shell:  
   

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Along with following custom commands:
     save <arg>               - save arg where arg is a file name from files command to the current pwd
     search <arg>             - search for arg within a job log from the last get command performed  
     submit <arg>             - where arg is a member name  
+    tailall <arg1> <arg2>    - where arg1 is job name, arg2 is optional and is line limit  
+                             - and all the job's combined spool files output is used
     v | visited              - a list of visited datasets  
   
 The following key combinations provide the following functionality within the shell:  

--- a/src/main/java/com/ZosShell.java
+++ b/src/main/java/com/ZosShell.java
@@ -4,6 +4,7 @@ import com.commands.Commands;
 import com.commands.History;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
+import com.log.JobLog;
 import com.security.Credentials;
 import com.utility.Util;
 import core.ZOSConnection;
@@ -197,6 +198,13 @@ public class ZosShell implements BiConsumer<TextIO, RunnerData> {
                 if (isParamsExceeded(2, params))
                     return;
                 jobLog = commands.get(currConnection, params);
+                break;
+            case "getall":
+                if (isParamsMissing(1, params))
+                    return;
+                if (isParamsExceeded(2, params))
+                    return;
+                jobLog = commands.getAll(currConnection, params, true);
                 break;
             case "history":
                 if (isParamsExceeded(2, params))

--- a/src/main/java/com/ZosShell.java
+++ b/src/main/java/com/ZosShell.java
@@ -301,6 +301,13 @@ public class ZosShell implements BiConsumer<TextIO, RunnerData> {
                     return;
                 commands.tail(currConnection, params);
                 break;
+            case "tailall":
+                if (isParamsMissing(1, params))
+                    return;
+                if (isParamsExceeded(3, params))
+                    return;
+                commands.tailAll(currConnection, params, true);
+                break;
             case "touch":
                 if (isParamsMissing(1, params))
                     return;

--- a/src/main/java/com/commands/Commands.java
+++ b/src/main/java/com/commands/Commands.java
@@ -1,10 +1,9 @@
 package com.commands;
 
-import com.JobLog;
+import com.log.JobLog;
 import core.ZOSConnection;
 import org.beryx.textio.TextTerminal;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -64,15 +63,19 @@ public class Commands {
     }
 
     public JobLog get(ZOSConnection connection, String[] params) {
-        var getJobOutput = new GetJobOutput(terminal, connection);
+        return getAll(connection, params, false);
+    }
+
+    public JobLog getAll(ZOSConnection connection, String[] params, boolean isAll) {
+        var getJobOutput = new GetJobOutput(terminal, connection, isAll);
         var output = getJobOutput.getLog(params[1]);
         if (output == null) return null;
-        Arrays.stream(output).forEach(terminal::println);
+        output.forEach(terminal::println);
         return new JobLog(params[1], output);
     }
 
     public void tail(ZOSConnection connection, String[] params) {
-        var getJobOutput = new GetJobOutput(terminal, connection);
+        var getJobOutput = new GetJobOutput(terminal, connection, false);
         getJobOutput.tail(params);
     }
 
@@ -116,9 +119,7 @@ public class Commands {
             var jobName = value.getJobName();
             var jobOutput = value.getOutput();
             terminal.println("searching " + jobName);
-            List<String> results = Arrays.stream(jobOutput)
-                    .filter(line -> line.contains(text))
-                    .collect(Collectors.toList());
+            List<String> results = jobOutput.stream().filter(line -> line.contains(text)).collect(Collectors.toList());
             if (!results.isEmpty())
                 results.forEach(terminal::println);
             else terminal.println("no results found in job log for " + jobName);

--- a/src/main/java/com/commands/Commands.java
+++ b/src/main/java/com/commands/Commands.java
@@ -75,7 +75,11 @@ public class Commands {
     }
 
     public void tail(ZOSConnection connection, String[] params) {
-        var getJobOutput = new GetJobOutput(terminal, connection, false);
+        tailAll(connection, params, false);
+    }
+
+    public void tailAll(ZOSConnection connection, String[] params, boolean isAll) {
+        var getJobOutput = new GetJobOutput(terminal, connection, isAll);
         getJobOutput.tail(params);
     }
 

--- a/src/main/java/com/commands/Commands.java
+++ b/src/main/java/com/commands/Commands.java
@@ -1,6 +1,8 @@
 package com.commands;
 
+import com.Constants;
 import com.log.JobLog;
+import com.utility.Util;
 import core.ZOSConnection;
 import org.beryx.textio.TextTerminal;
 
@@ -68,8 +70,21 @@ public class Commands {
 
     public JobLog getAll(ZOSConnection connection, String[] params, boolean isAll) {
         var getJobOutput = new GetJobOutput(terminal, connection, isAll);
-        var output = getJobOutput.getLog(params[1]);
-        if (output == null) return null;
+        List<String> output;
+        try {
+            output = getJobOutput.getLog(params[1]);
+        } catch (Exception e) {
+            if (e.getMessage().contains("timeout")) {
+                terminal.println("timeout, log may be too large to display, try again with \"get\" command...");
+                return null;
+            }
+            if (e.getMessage().contains("Connection refused")) {
+                terminal.println(Constants.SEVERE_ERROR);
+                return null;
+            }
+            Util.printError(terminal, e.getMessage());
+            return null;
+        }
         output.forEach(terminal::println);
         return new JobLog(params[1], output);
     }

--- a/src/main/java/com/commands/GetAllJobOutput.java
+++ b/src/main/java/com/commands/GetAllJobOutput.java
@@ -1,0 +1,34 @@
+package com.commands;
+
+import zosjobs.GetJobs;
+import zosjobs.input.JobFile;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+public class GetAllJobOutput implements Callable<List<String>> {
+
+    private final GetJobs getJobs;
+    private final List<JobFile> files;
+
+    public GetAllJobOutput(GetJobs getJobs, List<JobFile> files) {
+        this.getJobs = getJobs;
+        this.files = files;
+    }
+
+    @Override
+    public List<String> call() {
+        List<String> results = new ArrayList<>();
+        files.forEach(file -> {
+            try {
+                results.addAll(Arrays.asList(getJobs.getSpoolContent(file).split("\n")));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        return results;
+    }
+
+}

--- a/src/main/java/com/commands/GetJobOutput.java
+++ b/src/main/java/com/commands/GetJobOutput.java
@@ -59,7 +59,7 @@ public class GetJobOutput {
                 for (int i = size - lines; i < size; i++)
                     terminal.println(output.get(i));
             } else {
-                printAll((String[]) output.toArray(), size);
+                printAll(output, size);
             }
         } else {
             int LINES_LIMIT = 25;
@@ -67,7 +67,7 @@ public class GetJobOutput {
                 for (int i = size - LINES_LIMIT; i < size; i++)
                     terminal.println(output.get(i));
             } else {
-                printAll((String[]) output.toArray(), size);
+                printAll(output, size);
             }
         }
     }
@@ -93,9 +93,9 @@ public class GetJobOutput {
         return results;
     }
 
-    private void printAll(String[] output, int size) {
+    private void printAll(List<String> output, int size) {
         for (int i = 0; i < size; i++)
-            terminal.println(output[i]);
+            terminal.println(output.get(i));
     }
 
 }

--- a/src/main/java/com/commands/GetJobOutput.java
+++ b/src/main/java/com/commands/GetJobOutput.java
@@ -8,23 +8,28 @@ import zosjobs.GetJobs;
 import zosjobs.input.GetJobParams;
 import zosjobs.response.Job;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.*;
 
 public class GetJobOutput {
 
     private final TextTerminal<?> terminal;
     private final GetJobParams.Builder jobParams = new GetJobParams.Builder("*");
     private final GetJobs getJobs;
+    private boolean isAll;
 
-    public GetJobOutput(TextTerminal<?> terminal, ZOSConnection connection) {
+    public GetJobOutput(TextTerminal<?> terminal, ZOSConnection connection, boolean isAll) {
         this.terminal = terminal;
         this.getJobs = new GetJobs(connection);
+        this.isAll = isAll;
     }
 
-    public String[] getLog(String param) {
-        String[] output;
+    public List<String> getLog(String param) {
         try {
-            output = getJobLog(getJobs, jobParams.prefix(param).build());
+            return getJobLog(getJobs, jobParams.prefix(param).build());
         } catch (Exception e) {
             if (e.getMessage().contains("Connection refused")) {
                 terminal.println(Constants.SEVERE_ERROR);
@@ -33,13 +38,12 @@ public class GetJobOutput {
             Util.printError(terminal, e.getMessage());
             return null;
         }
-        return output;
     }
 
     public void tail(String[] params) {
         var output = getLog(params[1]);
         if (output == null) return;
-        var size = output.length;
+        var size = output.size();
         var lines = 0;
         if (params.length == 3) {
             try {
@@ -53,27 +57,40 @@ public class GetJobOutput {
         if (lines > 0) {
             if (lines < size) {
                 for (int i = size - lines; i < size; i++)
-                    terminal.println(output[i]);
+                    terminal.println(output.get(i));
             } else {
-                printAll(output, size);
+                printAll((String[]) output.toArray(), size);
             }
         } else {
             int LINES_LIMIT = 25;
             if (size > LINES_LIMIT) {
                 for (int i = size - LINES_LIMIT; i < size; i++)
-                    terminal.println(output[i]);
+                    terminal.println(output.get(i));
             } else {
-                printAll(output, size);
+                printAll((String[]) output.toArray(), size);
             }
         }
     }
 
-    private String[] getJobLog(GetJobs getJobs, GetJobParams jobParams) throws Exception {
+    private List<String> getJobLog(GetJobs getJobs, GetJobParams jobParams) throws Exception {
         final var jobs = getJobs.getJobsCommon(jobParams);
         // select the active one first not found then get the highest job number
         Optional<Job> job = jobs.stream().filter(j -> "ACTIVE".equalsIgnoreCase(j.getStatus().orElse(""))).findAny();
         final var files = getJobs.getSpoolFilesForJob(job.orElse(jobs.get(0)));
-        return getJobs.getSpoolContent(files.get(0)).split("\n");
+
+        if (!isAll) {
+            return Arrays.asList(getJobs.getSpoolContent(files.get(0)).split("\n"));
+        }
+
+        List<String> results = new ArrayList<>();
+        ExecutorService pool = Executors.newFixedThreadPool(1);
+        Future<List<String>> result = pool.submit(new GetAllJobOutput(getJobs, files));
+        try {
+            results = result.get(60, TimeUnit.SECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            terminal.println("timeout, log may be too large to display, try again with \"get\" command...");
+        }
+        return results;
     }
 
     private void printAll(String[] output, int size) {

--- a/src/main/java/com/log/JobLog.java
+++ b/src/main/java/com/log/JobLog.java
@@ -1,11 +1,13 @@
-package com;
+package com.log;
+
+import java.util.List;
 
 public class JobLog {
 
     private String jobName;
-    private String[] output;
+    private List<String> output;
 
-    public JobLog(String jobName, String[] output) {
+    public JobLog(String jobName, List<String> output) {
         this.jobName = jobName;
         this.output = output;
     }
@@ -14,7 +16,7 @@ public class JobLog {
         return jobName;
     }
 
-    public String[] getOutput() {
+    public List<String> getOutput() {
         return output;
     }
 


### PR DESCRIPTION
Get command only returns JESMSGLG spool output. Change readme to reflect this. Added getall command so that the end user can request all spool files output to be displayed. Sometimes this cannot be displayed as the output is too large! Added thread and timeout to handle this processing to avoid infinite hang or until JVM out of memory error. 

Did the same for tail command. 