### PR TITLE
Refactor History Scroll

### DIFF
--- a/src/main/java/com/commands/History.java
+++ b/src/main/java/com/commands/History.java
@@ -1,6 +1,7 @@
 package com.commands;
 
 import com.Constants;
+import com.data.CircularLinkedList;
 import org.beryx.textio.TextTerminal;
 
 import java.util.Arrays;
@@ -12,24 +13,20 @@ public class History {
 
     private final TextTerminal<?> terminal;
     private final List<String> commandLst = new LinkedList<>();
-    private int currCommandIndex = 0;
+    private final CircularLinkedList<String> circularLinkedList = new CircularLinkedList<>();
 
     public History(TextTerminal<?> terminal) {
         this.terminal = terminal;
     }
 
     public void listUpCommands(String prompt) {
-        var index = (currCommandIndex == 0) ? currCommandIndex = commandLst.size() :  currCommandIndex;
         terminal.resetLine();
-        terminal.printf(prompt + " " + commandLst.get(index - 1));
-        currCommandIndex--;
+        terminal.printf(prompt + " " + circularLinkedList.back());
     }
 
     public void listDownCommands(String prompt) {
-        var index = (currCommandIndex == commandLst.size()) ? currCommandIndex = 0 :  currCommandIndex;
         terminal.resetLine();
-        terminal.printf(prompt + " " + commandLst.get(index));
-        currCommandIndex++;
+        terminal.printf(prompt + " " + circularLinkedList.forward());
     }
 
     public void addHistory(String[] params) {
@@ -40,9 +37,11 @@ public class History {
         });
         String command = str.toString();
         if (!command.startsWith("history")) {
-            commandLst.add(str.toString());
+            commandLst.add(command);
+            circularLinkedList.add(command);
         }
-        currCommandIndex = 0;
+        // reset the currNode pointer used to handle history scrolling..
+        circularLinkedList.currNode = null;
     }
 
     public void displayHistory() {

--- a/src/main/java/com/data/CircularLinkedList.java
+++ b/src/main/java/com/data/CircularLinkedList.java
@@ -1,0 +1,69 @@
+package com.data;
+
+public class CircularLinkedList<T> {
+
+    public class Node<T> {
+        T data;
+        Node next;
+        Node prev;
+
+        public Node(T data) {
+            this.data = data;
+        }
+    }
+
+    public Node head = null;
+    public Node tail = null;
+    public Node prev = null;
+    public Node currNode = null;
+
+    // this function will add the new node at the end of the list.
+    public void add(T data) {
+        // create new node
+        Node newNode = new Node(data);
+        // checks if the list is empty.
+        if (head == null) {
+            // if list is empty, head, prev and tail would point to new node.
+            head = newNode;
+            tail = newNode;
+            prev = newNode;
+            newNode.next = head;
+        } else {
+            // tail will point to new node.
+            tail.next = newNode;
+            // hold a temp reference to current tail node
+            Node temp = tail;
+            // new node will become new tail.
+            tail = newNode;
+            // since, it is circular linked list tail will point to head.
+            tail.next = head;
+            // link to previous tail node
+            tail.prev = temp;
+            // circular double linked
+            head.prev = tail;
+        }
+    }
+
+    public T forward() {
+        if (currNode == null) {
+            currNode = this.head;
+        } else {
+            currNode = currNode.next;
+        }
+        return (T) currNode.data;
+    }
+
+    public T back() {
+        T result;
+        if (currNode == null) {
+            currNode = this.tail;
+            result = (T) currNode.data;
+            return result;
+        }
+
+        currNode = currNode.prev;
+        result = (T) currNode.data;
+        return result;
+    }
+
+}


### PR DESCRIPTION
Implemented a custom circular linked list to process an elegant scrolling ability instead of using the current java List. With the circular linked list all the edge cases are gone and becomes a simpler solution to use. I kept the java List in place for O(1) constant time lookup for history command reuse! This PR fixes #38 