### PR TITLE
Refactor History Scroll Handling

### DIFF
--- a/src/main/java/com/Constants.java
+++ b/src/main/java/com/Constants.java
@@ -17,6 +17,7 @@ public class Constants {
     public static final String DATASET_NOT_SPECIFIED = "no dataset specified, try again...";
     public static final String DELETE_OPS_NO_MEMBER_AND_DATASET_ERROR =
             "first argument invalid for rm operation, specified valid dataset or member or dataset(member), try again...";
+    public static final String DEFAULT_PROMPT = ">";
     public static final String DELETE_NOTHING_ERROR = "nothing to delete, try again...";
     public static final String DOWNLOAD_FAIL = "download failed, try again...";
     public static final long FUTURE_TIMEOUT_VALUE = 10;

--- a/src/main/java/com/ZosShell.java
+++ b/src/main/java/com/ZosShell.java
@@ -32,7 +32,7 @@ public class ZosShell implements BiConsumer<TextIO, RunnerData> {
     private static Commands commands;
     private static History history;
     private static JobOutput jobOutput;
-    private final static SwingTextTerminal mainTerminal = new SwingTextTerminal();
+    private static final SwingTextTerminal mainTerminal = new SwingTextTerminal();
 
     public static void main(String[] args) {
         Credentials.readCredentials(connections);

--- a/src/main/java/com/ZosShell.java
+++ b/src/main/java/com/ZosShell.java
@@ -46,7 +46,7 @@ public class ZosShell implements BiConsumer<TextIO, RunnerData> {
     }
 
     private static void setTerminalProperties() {
-        mainTerminal.setPaneTitle(Constants.APP_TITLE + " - CONNECTED TO " + currConnection.getHost().toUpperCase());
+        mainTerminal.setPaneTitle(Constants.APP_TITLE + " - " + currConnection.getHost().toUpperCase());
         mainTerminal.registerHandler("ctrl C", t -> {
             t.getTextPane().copy();
             return new ReadHandlerData(ReadInterruptionStrategy.Action.CONTINUE);
@@ -190,8 +190,7 @@ public class ZosShell implements BiConsumer<TextIO, RunnerData> {
                     return;
                 }
                 currConnection = commands.change(currConnection, params);
-                mainTerminal.setPaneTitle(Constants.APP_TITLE + " - CONNECTED TO " +
-                        currConnection.getHost().toUpperCase());
+                mainTerminal.setPaneTitle(Constants.APP_TITLE + " - " + currConnection.getHost().toUpperCase());
                 break;
             case "clearlog":
                 if (jobOutput != null) {

--- a/src/main/java/com/commands/History.java
+++ b/src/main/java/com/commands/History.java
@@ -3,8 +3,10 @@ package com.commands;
 import com.Constants;
 import com.data.CircularLinkedList;
 import com.google.common.base.Strings;
+import com.utility.Util;
 import org.beryx.textio.TextTerminal;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -81,12 +83,25 @@ public class History {
             return command;
         }
 
-        // remove ">" first parameter, added by listUpCommands or listDownCommands method
-        var newSize = command.length - 1;
-        var newCommand = new String[newSize];
-        for (int i = 1, j = 0; i < command.length; i++, j++) {
-            newCommand[j] = command[i];
+        List<String> list = new ArrayList<>(Arrays.asList(command));
+        // remove multiple spaces entered by end user and nulls
+        list.removeAll(Arrays.asList("", null));
+
+        String[] newCommand;
+        if (list.get(0).equals(Util.getPrompt())) {
+            newCommand = new String[list.size() - 1];
+            // remove prompt before sending new command
+            for (int i = 1, j = 0; i < list.size(); i++, j++) {
+                newCommand[j] = list.get(i);
+            }
+        } else {
+            // prompt not seen maybe removed by end user when scrolling through history
+            newCommand = new String[list.size()];
+            for (int i = 0; i < list.size(); i++) {
+                newCommand[i] = list.get(i);
+            }
         }
+
         return newCommand;
     }
 

--- a/src/main/java/com/utility/Util.java
+++ b/src/main/java/com/utility/Util.java
@@ -79,19 +79,6 @@ public class Util {
         }
     }
 
-    public static String getPrompt(ZOSConnection connection) {
-        var prompt = ">";
-        if (connection == null) {
-            return prompt;
-        }
-        var periodIndex = connection.getHost().indexOf(".");
-        if (periodIndex != -1) {
-            return connection.getHost().substring(0, connection.getHost().indexOf(".")) + prompt;
-        } else {
-            return connection.getHost() + prompt;
-        }
-    }
-
     public static boolean isHttpError(int statusCode) {
         return !((statusCode >= 200 && statusCode <= 299) || (statusCode >= 100 && statusCode <= 199));
     }
@@ -137,6 +124,10 @@ public class Util {
     public static String getMsgAfterArrow(String msg) {
         var index = msg.indexOf(Constants.ARROW) + Constants.ARROW.length();
         return msg.substring(index);
+    }
+
+    public static String getPrompt() {
+        return Constants.DEFAULT_PROMPT;
     }
 
 }


### PR DESCRIPTION
When using Up/Down arrow keys to scroll through history commands, the command prompt becomes editable and can cause havoc when removing prompt characters that contains a hostname which is currently used as a prompt. 