### PR TITLE
Record All Commands in History Without Exclusions or De-duplication

### DIFF
--- a/src/main/java/zos/shell/command/CommandRouter.java
+++ b/src/main/java/zos/shell/command/CommandRouter.java
@@ -25,12 +25,12 @@ public class CommandRouter {
         String cmdName = input.split("\\s+")[0].toLowerCase();
         CommandHandler handler = registry.get(cmdName);
 
+        HistorySingleton.getInstance().getHistory().addHistory(input.split("\\s+"));
+
         if (handler == null) {
             terminal.println(Constants.INVALID_COMMAND);
             return;
         }
-
-        HistorySingleton.getInstance().getHistory().addHistory(input.split("\\s+"));
 
         CommandContext ctx = new CommandContext(
                 terminal,

--- a/src/main/java/zos/shell/service/history/HistoryService.java
+++ b/src/main/java/zos/shell/service/history/HistoryService.java
@@ -51,15 +51,11 @@ public class HistoryService {
             str.append(" ");
         });
         var command = str.toString();
-        if (!command.startsWith("history")) {
-            if (commandLst.size() == Constants.HISTORY_SIZE) {
-                commandLst.remove(0);
-            }
-            if (commandLst.isEmpty() || !getLastHistory().equals(command)) {
-                commandLst.add(command);
-                circularLinkedList.add(command);
-            }
+        if (commandLst.size() == Constants.HISTORY_SIZE) {
+            commandLst.remove(0);
         }
+        commandLst.add(command);
+        circularLinkedList.add(command);
         // reset the currNode pointer used to handle history scrolling...
         circularLinkedList.currNode = null;
     }


### PR DESCRIPTION
This change simplifies and standardizes command history handling across the shell. Command history is now recorded consistently for every command invocation, including invalid commands and the history command itself, with no special-case exclusions or de-duplication. This ensures a complete, predictable, and strictly chronological history of user input.